### PR TITLE
Enable web builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ npx nx run-web <app-name>
 npx nx bundle <app-name>
 npx nx bundle <app-name> --platform=ios
 npx nx bundle <app-name> --platform=android
+npx nx bundle <app-name> --platform=web
 ```
 
 ## Using components from React library

--- a/packages/react-native-expo/src/builders/bundle/schema.json
+++ b/packages/react-native-expo/src/builders/bundle/schema.json
@@ -7,7 +7,7 @@
       "description": "Platform to build for (ios, android).",
       "anyOf": [
         {
-          "enum": ["android", "ios"]
+          "enum": ["android", "ios", "web"]
         }
       ]
     }


### PR DESCRIPTION
When trying to build for the web, using `npx nx bundle <app-name> --platform=web` I received this error:

![image](https://user-images.githubusercontent.com/2213636/123344165-1d1fa580-d508-11eb-88a0-3ecd4c4077aa.png)

The fix was just to add "web" to the builder schema file for the "bundle" 

Also updated the docs with the web flavored build command.

Thanks!